### PR TITLE
Add random distribution op + x**y + various modifications

### DIFF
--- a/LibTensorFlow-Core/TF_Graph.class.st
+++ b/LibTensorFlow-Core/TF_Graph.class.st
@@ -258,6 +258,16 @@ TF_Graph >> mul: nameString described: aBlock [
 	^self newOperation: 'Mul' named: nameString described: aBlock
 ]
 
+{ #category : #'random operations' }
+TF_Graph >> multinomialShaped: shapeConstant numSamples: aNumber [
+	"Draws samples from a multinomial distribution."
+	| numSamples|
+	numSamples := self const: aNumber asInt32Tensor .
+
+	^ shapeConstant op: 'Multinomial' withAll: {numSamples} named: 'Mltn' described:
+	[:description |]
+]
+
 { #category : #'root operations' }
 TF_Graph >> nameFor: namePrefix [
 	^ context, namePrefix,'_',self operationsCount printString.
@@ -351,6 +361,25 @@ TF_Graph >> outputDimensionsCount: aTF_Output [
 	^ answer
 ]
 
+{ #category : #'random operations' }
+TF_Graph >> parametrizedTruncatedNormalShaped: shapeArray means: means stdevs: stdevs minVals:minVals maxVals:maxVals [
+	| shape meansTensor stdevsTensor minValsTensor maxValsTensor |
+	shape := self const: shapeArray asInt32Tensor.
+	meansTensor := self const: means asFloatTensor.
+	stdevsTensor := self const: stdevs asFloatTensor.
+	minValsTensor := self const: minVals asFloatTensor.
+	maxValsTensor := self const: maxVals asFloatTensor.	
+	^ shape op: 'ParameterizedTruncatedNormal' withAll: {meansTensor. stdevsTensor. minValsTensor.maxValsTensor} named: 'Mltn' described:
+	[:description |]
+]
+
+{ #category : #'random operations' }
+TF_Graph >> parametrizedTruncatedNormalShaped: shapeArray stddev: aNumber [
+	| random |
+	random := self truncatedNormalRandomShaped: shapeArray.
+	^ random @* (self const: aNumber asTensor)
+]
+
 { #category : #'root operations' }
 TF_Graph >> placeholder: nameString type: typeInteger [
 	^ self
@@ -358,6 +387,79 @@ TF_Graph >> placeholder: nameString type: typeInteger [
 		named: nameString
 		described: [:description |
 			description at: 'dtype' putType: typeInteger]
+]
+
+{ #category : #'random operations' }
+TF_Graph >> randomGamma:shapeArray alpha: alpha [ 
+	"Outputs random values from a uniform distribution."
+	| shape alphaTensor |
+	shape := self const: shapeArray asInt32Tensor.
+	alphaTensor:= self const: alpha asFloatTensor.
+
+	^ shape op: 'RandomGamma' withAll: {alphaTensor.} named: 'RG' described:
+	[:description |]
+]
+
+{ #category : #'random operations' }
+TF_Graph >> randomNormalShaped:shapeArray [
+	"Outputs random values from a normal distribution"
+	| shape |
+	shape := self const: shapeArray asInt32Tensor.
+	^ shape unaryOp: 'RandomStandardNormal' described: [:description |
+		description at: 'dtype' putType: TF_Tensor typeFloat]
+]
+
+{ #category : #'random operations' }
+TF_Graph >> randomNormalShaped: shapeArray stddev: aNumber [
+	| random |
+	random := self randomNormalShaped: shapeArray.
+	^ random @* (self const: aNumber asTensor)
+]
+
+{ #category : #'random operations' }
+TF_Graph >> randomPoisson:shapeArray rate: rate [ 
+	"Outputs random values from a uniform distribution."
+	| shape  rateTensor |
+	shape := self const: shapeArray asInt32Tensor.
+	rateTensor:= self const: rate asFloatTensor.
+
+	^ shape op: 'RandomPoissonV2' withAll: {rateTensor.} named: 'RP' described:
+	[:description |]
+]
+
+{ #category : #'random operations' }
+TF_Graph >> randomShuffle: aTensor [
+	
+	| shape |
+	shape := self const: aTensor.
+	^ shape unaryOp: 'RandomShuffle' described: [:description |]
+]
+
+{ #category : #'random operations' }
+TF_Graph >> randomUniformIntShaped:shapeArray minVal: minTensorAsArray maxVal:maxTensorAsArray [
+	"Outputs random values from a uniform distribution."
+	| shape mini maxi |
+	shape := self const: shapeArray asInt32Tensor.
+	mini:= self const: minTensorAsArray asInt32Tensor.
+	maxi := self const: maxTensorAsArray  asInt32Tensor.
+	^ shape op: 'RandomUniformInt' withAll: {mini. maxi.} named: 'RUI' described:
+	[:description |]
+]
+
+{ #category : #'random operations' }
+TF_Graph >> randomUniformShaped:shapeArray [
+	"Outputs random values from a uniform distribution."
+	| shape |
+	shape := self const: shapeArray asInt32Tensor.
+	^ shape unaryOp: 'RandomUniform' described: [:description |
+		description at: 'dtype' putType: TF_Tensor typeFloat]
+]
+
+{ #category : #'random operations' }
+TF_Graph >> randomUniformShaped: shapeArray stddev: aNumber [
+	| random |
+	random := self randomUniformIntShaped: shapeArray.
+	^ random @* (self const: aNumber asTensor)
 ]
 
 { #category : #outputs }

--- a/LibTensorFlow-Core/TF_Operation.class.st
+++ b/LibTensorFlow-Core/TF_Operation.class.st
@@ -17,6 +17,11 @@ TF_Operation >> * aTF_Operation [
 ]
 
 { #category : #'ops binary' }
+TF_Operation >> ** aTF_Operation [
+	^ self binaryOp: 'Pow' with: aTF_Operation
+]
+
+{ #category : #'ops binary' }
 TF_Operation >> *\ aTF_Operation [
 	^ self
 		binaryOp: 'MatMul'
@@ -142,7 +147,7 @@ TF_Operation >> assign: aTF_Operation [
 	^ self
 		binaryOp: 'Assign'
 		with: aTF_Operation
-		named: self name, '_initializer'
+		named: (self nameFor: self name) , '_initializer'
 ]
 
 { #category : #attributes }
@@ -306,6 +311,13 @@ TF_Operation >> inverse [
 { #category : #'ops binary' }
 TF_Operation >> library [
 	^ TensorFlowCAPI current
+]
+
+{ #category : #accessing }
+TF_Operation >> log [
+	"CComputes natural logarithm of x element-wise"
+
+	^ self unaryOp: 'Log'
 ]
 
 { #category : #'ops binary' }

--- a/LibTensorFlow-Core/TF_Session.class.st
+++ b/LibTensorFlow-Core/TF_Session.class.st
@@ -19,12 +19,14 @@ TF_Session class >> finalizeResourceData: handle [
 
 { #category : #'instance creation' }
 TF_Session class >> on: aTF_Graph [
-	| options status answer |
+	| options status answer session |
 	options := TF_SessionOptions create.
 	status := TF_Status create.
 	answer := TensorFlowCAPI current newSession: aTF_Graph options: options status: status.
 	status check.
-	^ answer autoRelease
+	session := answer autoRelease.
+	aTF_Graph initializeOn:session.
+	^ session
 ]
 
 { #category : #release }

--- a/LibTensorFlow-Core/TensorFlowCAPI.class.st
+++ b/LibTensorFlow-Core/TensorFlowCAPI.class.st
@@ -410,10 +410,9 @@ TensorFlowCAPI >> importGraphDefInto: aTF_Graph from: aTF_Buffer options: aTF_Im
 	^ self ffiCall: #(void TF_GraphImportGraphDef #(TF_Graph * aTF_Graph, TF_Buffer * aTF_Buffer, TF_ImportGraphDefOptions * aTF_ImportGraphDefOptions, TF_Status * aTF_Status)) module: TensorFlowCAPI
 ]
 
-{ #category : #utils }
+{ #category : #'accessing platform' }
 TensorFlowCAPI >> macModuleName [
-
-^ '/usr/local/Cellar/libtensorflow/1.9.0/lib/libtensorflow.so'
+  ^ '/usr/local/Cellar/libtensorflow/1.8.0/lib/libtensorflow.so'
 ]
 
 { #category : #status }

--- a/LibTensorFlow-Core/TensorFlowOperationsTest.class.st
+++ b/LibTensorFlow-Core/TensorFlowOperationsTest.class.st
@@ -82,7 +82,173 @@ TensorFlowOperationsTest >> standardDeviation: aCollectionOfNumbers [
 	^(self variance: aCollectionOfNumbers) sqrt
 ]
 
-{ #category : #'binary operations' }
+{ #category : #'random ops' }
+TensorFlowOperationsTest >> testGraphMultinomialShaped [
+	| graph session result random values shape |	
+	graph := TF_Graph create.
+	shape := graph const:  {{10. 10}} asFloatTensor.
+	shape log.
+	random := graph multinomialShaped: shape numSamples: 25.
+
+	session := TF_Session on: graph.
+	result := session runOutput: (random output: 0).
+	values := result allFloats.
+	
+		
+	self assert: result shape equals: #(1 25).
+	self assert: values size equals: 25.
+	self assert: values min  >= 0.
+	self assert: values max <=1.
+
+
+	
+]
+
+{ #category : #'random ops' }
+TensorFlowOperationsTest >> testGraphNormal [
+	| graph session result random values std theoreticalDecile expected |
+	graph := TF_Graph create.
+	random := graph randomNormalShaped: #(100 100 10).
+	session := TF_Session on: graph.
+	result := session runOutput: (random output: 0).
+	values := result allFloats.
+	theoreticalDecile := -1.1840324666939051.
+	std := self standardDeviation: values.
+	self assert: result shape equals: #(100 100 10).
+	self assert: values size equals: 100 * 100 * 10.
+	self assert: values min + 2 < 0.01.
+	self assert: 2 - values max < 0.01.
+	self assert: (self mean: values) abs < (0.01 * std).
+	expected := {theoreticalDecile.
+	theoreticalDecile negated}.
+	#(0.1 0.9)
+		with: expected
+		do: [ :p :e | 
+			| observed |
+			observed := self percentile: p from: values.
+			self assert: (observed - e) abs < 0.2 ]
+]
+
+{ #category : #'random ops' }
+TensorFlowOperationsTest >> testGraphNormalStddev [
+	| graph session result random values sigma twoSigma std theoreticalDecile expected |	
+	graph := TF_Graph create.
+	
+	sigma := 3.14.
+	twoSigma := 2 * sigma.
+	random := graph randomNormalShaped: #(100 100 10) stddev: sigma.
+
+	session := TF_Session on: graph.
+	result := session runOutput: (random output: 0).
+	values := result allFloats.
+	
+	std := self standardDeviation: values.
+	theoreticalDecile := -1.1840324666939051.
+		
+	self assert: result shape equals: #(100 100 10).
+	self assert: values size equals: 100*100*10.
+	self assert: twoSigma - (values min abs)  < 0.1.
+	self assert: twoSigma - values max < 0.1.
+	self assert: (self mean: values) abs < (0.01 * std).
+	expected :=  { theoreticalDecile * sigma. 
+							theoreticalDecile negated * sigma.
+							-2.
+							2}.
+
+	
+]
+
+{ #category : #'random ops' }
+TensorFlowOperationsTest >> testGraphParametrizedTruncatedNormal [
+	| graph session result random values std|
+	graph := TF_Graph create.
+	random := graph parametrizedTruncatedNormalShaped: #(100 100 10) 
+																means:#(0) 
+																stdevs:#(1)
+																minVals:#(-1) 
+																maxVals:#(1).
+	session := TF_Session on: graph.
+	result := session runOutput: (random output: 0).
+	values := result allFloats.
+
+	std := self standardDeviation: values.
+	self assert: result shape equals: #(100 100 10).
+	self assert: values size equals: 100 * 100 * 10.
+	self assert: values min > -1.
+	self assert: values max < 1.
+
+]
+
+{ #category : #'random ops' }
+TensorFlowOperationsTest >> testGraphRandomGamma [
+	| graph session result random values std|
+	graph := TF_Graph create.
+	random := graph randomGamma: #(100 100 10) alpha:1.
+													
+	session := TF_Session on: graph.
+	result := session runOutput: (random output: 0).
+	values := result allFloats.
+
+	std := self standardDeviation: values.
+	self assert: result shape equals: #(100 100 10).
+	self assert: values size equals: 100 * 100 * 10.
+
+
+]
+
+{ #category : #'random ops' }
+TensorFlowOperationsTest >> testGraphRandomPoisson [
+	| graph session result random values std|
+	graph := TF_Graph create.
+	random := graph randomPoisson: #(100 100 10) rate:1.
+													
+	session := TF_Session on: graph.
+	result := session runOutput: (random output: 0).
+	values := result allFloats.
+
+	std := self standardDeviation: values.
+	self assert: result shape equals: #(100 100 10).
+	self assert: values size equals: 100 * 100 * 10.
+
+
+]
+
+{ #category : #'random ops' }
+TensorFlowOperationsTest >> testGraphRandomUniformShaped [
+	| graph session result random values |	
+	graph := TF_Graph create.
+	
+	random := graph randomUniformIntShaped: {100. 100. 10} minVal: 3 maxVal: 5.
+
+	session := TF_Session on: graph.
+	result := session runOutput: (random output: 0).
+	values := result allInt32s.
+	
+		
+	self assert: result shape equals: #(100 100 10).
+	self assert: values size equals: 100*100*10.
+	self assert: values min  >= 3.
+	self assert: values max <5.
+
+
+	
+]
+
+{ #category : #'random ops' }
+TensorFlowOperationsTest >> testGraphTensorRandomShuffle [
+	| graph session result random values |
+	graph := TF_Graph create.
+	random := graph randomShuffle: {{1. 2. 3}. {4. 5. 6}. {7. 8. 9}} asInt32Tensor.
+	session := TF_Session on: graph.
+	result := session runOutput: (random output: 0).
+	values := result allFloats.
+	
+	self assert: result shape equals: #(3 3).
+	self assert: values size equals: 9.
+
+]
+
+{ #category : #'random ops' }
 TensorFlowOperationsTest >> testGraphTruncatedNormal [
 	| graph session result random values std theoreticalDecile expected |
 	graph := TF_Graph create.
@@ -107,7 +273,7 @@ TensorFlowOperationsTest >> testGraphTruncatedNormal [
 			self assert: (observed - e) abs < 0.2 ]
 ]
 
-{ #category : #'binary operations' }
+{ #category : #'random ops' }
 TensorFlowOperationsTest >> testGraphTruncatedNormalStddev [
 	| graph session result random values sigma twoSigma std theoreticalDecile expected |	
 	graph := TF_Graph create.


### PR DESCRIPTION
added random distribution operations .
added x ** y (x powered y)
mac module name
Test sare only check ing the correct execution,  do not check the validity  of the result.
Session on: call graph initializeOn:self in order to initialize all the variables.
#assign: always assigned the same op name, you can not do thinks like a  graph assign:  a + 1 .0 asTensor.  Solved using ( ..nameFor:self name) , 'initializer'.